### PR TITLE
Check out SVN inside of Git clone

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -54,9 +54,6 @@ tooling:
     service: appserver
   svn:
     service: appserver
-  svn-git-up:
-    service: appserver
-    cmd: "bash $LANDO_MOUNT/bin/svn-git-up"
   phpunit:
     service: appserver
     # TODO: This is not the ideal way to force the environment variable to be set, but the .env file does not always persist due to a Lando bug.

--- a/.lando.yml
+++ b/.lando.yml
@@ -36,7 +36,7 @@ services:
       - if [ ! -e $LANDO_MOUNT/public/core-dev/vendor ]; then cd $LANDO_MOUNT/public/core-dev && composer install; fi
       - if [ ! -e $LANDO_MOUNT/public/core-dev/node_modules ]; then cd $LANDO_MOUNT/public/core-dev && npm install; fi
       - if [ ! -e $LANDO_MOUNT/public/core-dev/build ]; then cd $LANDO_MOUNT/public/core-dev && npx grunt; fi
-      - cd $LANDO_MOUNT/public/core-dev; if ! git config -l --local | grep -q 'alias.svn-up'; then git config alias.svn-up '! cd $(git rev-parse --show-toplevel) && ../../bin/svn-git-up $1'; fi
+      - cd $LANDO_MOUNT/public/core-dev; if ! git config -l --local | grep -q 'alias.svn-up'; then git config alias.svn-up '! ../../bin/svn-git-up $1'; fi
       - if ! wp core is-installed; then wp core install --url="https://$LANDO_APP_NAME.$LANDO_DOMAIN/" --title="WordPress Develop" --admin_name="admin" --admin_email="admin@local.test" --admin_password="password"; fi
 
 tooling:

--- a/.lando.yml
+++ b/.lando.yml
@@ -30,7 +30,7 @@ services:
     run:
       # Setup WordPress for contributing.
       - if [ ! -e $LANDO_MOUNT/public/core-dev ]; then git clone https://github.com/WordPress/wordpress-develop.git $LANDO_MOUNT/public/core-dev; fi
-      - if [ ! -e $LANDO_MOUNT/public/core-dev/.svn ]; then echo "Checking out WordPress SVN..."; cd $LANDO_MOUNT; svn co -q --ignore-externals https://develop.svn.wordpress.org/trunk/ tmp-svn; mv tmp-svn/.svn public/core-dev/.svn; rm -rf tmp-svn; fi
+      - if [ ! -e $LANDO_MOUNT/public/core-dev/.svn ]; then cd $LANDO_MOUNT; svn co --ignore-externals https://develop.svn.wordpress.org/trunk/ tmp-svn; mv tmp-svn/.svn public/core-dev/.svn; rm -rf tmp-svn; fi
       - if [ ! -e $LANDO_MOUNT/public/core-dev/wp-config.php ]; then cp $LANDO_MOUNT/config/wp-config.php $LANDO_MOUNT/public/core-dev/wp-config.php; fi
       - if [ ! -e $LANDO_MOUNT/public/core-dev/wp-tests-config.php ]; then cp $LANDO_MOUNT/config/wp-tests-config.php $LANDO_MOUNT/public/core-dev/wp-tests-config.php; fi
       - if [ ! -e $LANDO_MOUNT/public/core-dev/vendor ]; then cd $LANDO_MOUNT/public/core-dev && composer install; fi

--- a/.lando.yml
+++ b/.lando.yml
@@ -29,7 +29,7 @@ services:
       - if [ ! -e $LANDO_MOUNT/wp-cli.yml ]; then cp $LANDO_MOUNT/config/wp-cli.yml $LANDO_MOUNT/wp-cli.yml; fi
     run:
       # Setup WordPress for contributing.
-      - if [ ! -e $LANDO_MOUNT/public/core-dev ]; then git clone --depth 1 https://github.com/WordPress/wordpress-develop.git $LANDO_MOUNT/public/core-dev; fi
+      - if [ ! -e $LANDO_MOUNT/public/core-dev ]; then git clone https://github.com/WordPress/wordpress-develop.git $LANDO_MOUNT/public/core-dev; fi
       - if [ ! -e $LANDO_MOUNT/public/core-dev/.svn ]; then echo "Checking out WordPress SVN..."; cd $LANDO_MOUNT; svn co -q --ignore-externals https://develop.svn.wordpress.org/trunk/ tmp-svn; mv tmp-svn/.svn public/core-dev/.svn; rm -rf tmp-svn; fi
       - if [ ! -e $LANDO_MOUNT/public/core-dev/wp-config.php ]; then cp $LANDO_MOUNT/config/wp-config.php $LANDO_MOUNT/public/core-dev/wp-config.php; fi
       - if [ ! -e $LANDO_MOUNT/public/core-dev/wp-tests-config.php ]; then cp $LANDO_MOUNT/config/wp-tests-config.php $LANDO_MOUNT/public/core-dev/wp-tests-config.php; fi

--- a/.lando.yml
+++ b/.lando.yml
@@ -36,7 +36,7 @@ services:
       - if [ ! -e $LANDO_MOUNT/public/core-dev/vendor ]; then cd $LANDO_MOUNT/public/core-dev && composer install; fi
       - if [ ! -e $LANDO_MOUNT/public/core-dev/node_modules ]; then cd $LANDO_MOUNT/public/core-dev && npm install; fi
       - if [ ! -e $LANDO_MOUNT/public/core-dev/build ]; then cd $LANDO_MOUNT/public/core-dev && npx grunt; fi
-      # Install WordPress (for both variants).
+      - cd $LANDO_MOUNT/public/core-dev; if ! git config -l --local | grep -q 'alias.svn-up'; then git config alias.svn-up '! cd $(git rev-parse --show-toplevel) && ../../bin/svn-git-up $1'; fi
       - if ! wp core is-installed; then wp core install --url="https://$LANDO_APP_NAME.$LANDO_DOMAIN/" --title="WordPress Develop" --admin_name="admin" --admin_email="admin@local.test" --admin_password="password"; fi
 
 tooling:

--- a/.lando.yml
+++ b/.lando.yml
@@ -29,13 +29,16 @@ services:
       - if [ ! -e $LANDO_MOUNT/wp-cli.yml ]; then cp $LANDO_MOUNT/config/wp-cli.yml $LANDO_MOUNT/wp-cli.yml; fi
     run:
       # Setup WordPress for contributing via git.
+      # TODO: Rename core-git to core or core-dev.
       - if [ ! -e $LANDO_MOUNT/public/core-git ]; then git clone --depth 1 https://github.com/WordPress/wordpress-develop.git $LANDO_MOUNT/public/core-git; fi
+      - if [ ! -e $LANDO_MOUNT/public/core-git/.svn ]; then echo "Checking out WordPress SVN..."; cd $LANDO_MOUNT; svn co -q --ignore-externals https://develop.svn.wordpress.org/trunk/ tmp-svn; mv tmp-svn/.svn public/core-git/.svn; rm -rf tmp-svn; fi
       - if [ ! -e $LANDO_MOUNT/public/core-git/wp-config.php ]; then cp $LANDO_MOUNT/config/wp-config.php $LANDO_MOUNT/public/core-git/wp-config.php; fi
       - if [ ! -e $LANDO_MOUNT/public/core-git/wp-tests-config.php ]; then cp $LANDO_MOUNT/config/wp-tests-config.php $LANDO_MOUNT/public/core-git/wp-tests-config.php; fi
       - if [ ! -e $LANDO_MOUNT/public/core-git/vendor ]; then cd $LANDO_MOUNT/public/core-git && composer install; fi
       - if [ ! -e $LANDO_MOUNT/public/core-git/node_modules ]; then cd $LANDO_MOUNT/public/core-git && npm install; fi
       - if [ ! -e $LANDO_MOUNT/public/core-git/build ]; then cd $LANDO_MOUNT/public/core-git && npx grunt; fi
       # Setup WordPress for contributing via SVN.
+      # TODO: Remove the following once SVN above is good to go.
       - if [ ! -e $LANDO_MOUNT/public/trunk-svn ]; then svn co https://develop.svn.wordpress.org/trunk/ $LANDO_MOUNT/public/trunk-svn; fi
       - if [ ! -e $LANDO_MOUNT/public/trunk-svn/wp-config.php ]; then cp $LANDO_MOUNT/config/wp-config.php $LANDO_MOUNT/public/trunk-svn/wp-config.php; fi
       - if [ ! -e $LANDO_MOUNT/public/trunk-svn/wp-tests-config.php ]; then cp $LANDO_MOUNT/config/wp-tests-config.php $LANDO_MOUNT/public/trunk-svn/wp-tests-config.php; fi
@@ -60,6 +63,9 @@ tooling:
     service: appserver
   svn:
     service: appserver
+  svn-git-up:
+    service: appserver
+    cmd: "bash $LANDO_MOUNT/bin/svn-git-up"
   phpunit:
     service: appserver
     # TODO: This is not the ideal way to force the environment variable to be set, but the .env file does not always persist due to a Lando bug.

--- a/.lando.yml
+++ b/.lando.yml
@@ -28,23 +28,14 @@ services:
       - if [ ! -e $LANDO_MOUNT/.env ]; then cp $LANDO_MOUNT/config/.env $LANDO_MOUNT/.env && sed -i "s#/app#$LANDO_MOUNT#" $LANDO_MOUNT/.env; fi
       - if [ ! -e $LANDO_MOUNT/wp-cli.yml ]; then cp $LANDO_MOUNT/config/wp-cli.yml $LANDO_MOUNT/wp-cli.yml; fi
     run:
-      # Setup WordPress for contributing via git.
-      # TODO: Rename core-git to core or core-dev.
-      - if [ ! -e $LANDO_MOUNT/public/core-git ]; then git clone --depth 1 https://github.com/WordPress/wordpress-develop.git $LANDO_MOUNT/public/core-git; fi
-      - if [ ! -e $LANDO_MOUNT/public/core-git/.svn ]; then echo "Checking out WordPress SVN..."; cd $LANDO_MOUNT; svn co -q --ignore-externals https://develop.svn.wordpress.org/trunk/ tmp-svn; mv tmp-svn/.svn public/core-git/.svn; rm -rf tmp-svn; fi
-      - if [ ! -e $LANDO_MOUNT/public/core-git/wp-config.php ]; then cp $LANDO_MOUNT/config/wp-config.php $LANDO_MOUNT/public/core-git/wp-config.php; fi
-      - if [ ! -e $LANDO_MOUNT/public/core-git/wp-tests-config.php ]; then cp $LANDO_MOUNT/config/wp-tests-config.php $LANDO_MOUNT/public/core-git/wp-tests-config.php; fi
-      - if [ ! -e $LANDO_MOUNT/public/core-git/vendor ]; then cd $LANDO_MOUNT/public/core-git && composer install; fi
-      - if [ ! -e $LANDO_MOUNT/public/core-git/node_modules ]; then cd $LANDO_MOUNT/public/core-git && npm install; fi
-      - if [ ! -e $LANDO_MOUNT/public/core-git/build ]; then cd $LANDO_MOUNT/public/core-git && npx grunt; fi
-      # Setup WordPress for contributing via SVN.
-      # TODO: Remove the following once SVN above is good to go.
-      - if [ ! -e $LANDO_MOUNT/public/trunk-svn ]; then svn co https://develop.svn.wordpress.org/trunk/ $LANDO_MOUNT/public/trunk-svn; fi
-      - if [ ! -e $LANDO_MOUNT/public/trunk-svn/wp-config.php ]; then cp $LANDO_MOUNT/config/wp-config.php $LANDO_MOUNT/public/trunk-svn/wp-config.php; fi
-      - if [ ! -e $LANDO_MOUNT/public/trunk-svn/wp-tests-config.php ]; then cp $LANDO_MOUNT/config/wp-tests-config.php $LANDO_MOUNT/public/trunk-svn/wp-tests-config.php; fi
-      - if [ ! -e $LANDO_MOUNT/public/trunk-svn/vendor ]; then cd $LANDO_MOUNT/public/trunk-svn && composer install; fi
-      - if [ ! -e $LANDO_MOUNT/public/trunk-svn/node_modules ]; then cd $LANDO_MOUNT/public/trunk-svn && npm install; fi
-      - if [ ! -e $LANDO_MOUNT/public/trunk-svn/build ]; then cd $LANDO_MOUNT/public/trunk-svn && npx grunt; fi
+      # Setup WordPress for contributing.
+      - if [ ! -e $LANDO_MOUNT/public/core-dev ]; then git clone --depth 1 https://github.com/WordPress/wordpress-develop.git $LANDO_MOUNT/public/core-dev; fi
+      - if [ ! -e $LANDO_MOUNT/public/core-dev/.svn ]; then echo "Checking out WordPress SVN..."; cd $LANDO_MOUNT; svn co -q --ignore-externals https://develop.svn.wordpress.org/trunk/ tmp-svn; mv tmp-svn/.svn public/core-dev/.svn; rm -rf tmp-svn; fi
+      - if [ ! -e $LANDO_MOUNT/public/core-dev/wp-config.php ]; then cp $LANDO_MOUNT/config/wp-config.php $LANDO_MOUNT/public/core-dev/wp-config.php; fi
+      - if [ ! -e $LANDO_MOUNT/public/core-dev/wp-tests-config.php ]; then cp $LANDO_MOUNT/config/wp-tests-config.php $LANDO_MOUNT/public/core-dev/wp-tests-config.php; fi
+      - if [ ! -e $LANDO_MOUNT/public/core-dev/vendor ]; then cd $LANDO_MOUNT/public/core-dev && composer install; fi
+      - if [ ! -e $LANDO_MOUNT/public/core-dev/node_modules ]; then cd $LANDO_MOUNT/public/core-dev && npm install; fi
+      - if [ ! -e $LANDO_MOUNT/public/core-dev/build ]; then cd $LANDO_MOUNT/public/core-dev && npx grunt; fi
       # Install WordPress (for both variants).
       - if ! wp core is-installed; then wp core install --url="https://$LANDO_APP_NAME.$LANDO_DOMAIN/" --title="WordPress Develop" --admin_name="admin" --admin_email="admin@local.test" --admin_password="password"; fi
 
@@ -69,7 +60,7 @@ tooling:
   phpunit:
     service: appserver
     # TODO: This is not the ideal way to force the environment variable to be set, but the .env file does not always persist due to a Lando bug.
-    cmd: "WP_TESTS_DIR=/app/public/core-git/tests/phpunit/ phpunit"
+    cmd: "WP_TESTS_DIR=/app/public/core-dev/tests/phpunit/ phpunit"
   log:
     service: appserver
     cmd: "if [ ! -e /app/public/content/debug.log ]; then touch /app/public/content/debug.log; fi; echo 'Assuming WP_DEBUG_LOG enabled, tailing /app/public/content/debug.log...'; tail -f /app/public/content/debug.log"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "files.exclude": {
-        "public/core-git/build": true
+        "public/core-dev/build": true
     },
     "search.useIgnoreFiles": false
 }

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ If this is your very first Lando project, make sure that your system trusts the 
 
 ## Usage
 
-* WordPress core contributions can happen either via the `public/core-git` directory (if you prefer to use git) or via the `public/trunk-svn` directory (if you prefer to use SVN).
+* WordPress core contributions can happen either via the `public/core-dev` directory (if you prefer to use git) or via the `public/trunk-svn` directory (if you prefer to use SVN).
 * WordPress plugin and theme development should happen in `public/content`, which is a custom `wp-content` directory, decoupled from the WordPress core repository. The environment automatically takes care of setting WordPress constants appropriately so that the core and content directories are connected, so you don't need to worry about this.
-* By default, the website you open from the browser will run off the `public/core-git/build` directory. If you prefer to use WordPress core from another directory (for example `public/trunk-svn/build`), you need to update the following configurations:
+* By default, the website you open from the browser will run off the `public/core-dev/build` directory. If you prefer to use WordPress core from another directory (for example `public/trunk-svn/build`), you need to update the following configurations:
     * all three variables defined in `.env`
     * the path defined in `wp-cli.yml`
     * the hardcoded `WP_TESTS_DIR` value at the very bottom of `.lando.yml`

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If this is your very first Lando project, make sure that your system trusts the 
 
 ## Usage
 
-* WordPress core contributions can happen either via the `public/core-dev` directory (if you prefer to use git) or via the `public/trunk-svn` directory (if you prefer to use SVN).
+* WordPress core contributions are done in the `public/core-dev` directory which is both a Git clone and SVN checkout. To update the Git and SVN in tandem, do `git svn-up` in that directory to update to the latest `trunk`/`master`. To switch/update another branch, do `git svn-up $branch`. This `git svn-up` command is an alias to the repo's [`bin/svn-git-up`](bin/svn-git-up) script.
 * WordPress plugin and theme development should happen in `public/content`, which is a custom `wp-content` directory, decoupled from the WordPress core repository. The environment automatically takes care of setting WordPress constants appropriately so that the core and content directories are connected, so you don't need to worry about this.
 * By default, the website you open from the browser will run off the `public/core-dev/build` directory. If you prefer to use WordPress core from another directory (for example `public/core-dev/src`), you need to update the following configurations:
     * all three variables defined in `.env`

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If this is your very first Lando project, make sure that your system trusts the 
 
 * WordPress core contributions can happen either via the `public/core-dev` directory (if you prefer to use git) or via the `public/trunk-svn` directory (if you prefer to use SVN).
 * WordPress plugin and theme development should happen in `public/content`, which is a custom `wp-content` directory, decoupled from the WordPress core repository. The environment automatically takes care of setting WordPress constants appropriately so that the core and content directories are connected, so you don't need to worry about this.
-* By default, the website you open from the browser will run off the `public/core-dev/build` directory. If you prefer to use WordPress core from another directory (for example `public/trunk-svn/build`), you need to update the following configurations:
+* By default, the website you open from the browser will run off the `public/core-dev/build` directory. If you prefer to use WordPress core from another directory (for example `public/core-dev/src`), you need to update the following configurations:
     * all three variables defined in `.env`
     * the path defined in `wp-cli.yml`
     * the hardcoded `WP_TESTS_DIR` value at the very bottom of `.lando.yml`

--- a/bin/svn-git-up
+++ b/bin/svn-git-up
@@ -3,7 +3,7 @@
 #
 # Pass a branch name like 4.6 as the sole argument to checkout that branch. Otherwise, master/trunk is checked out.
 
-cd $(dirname "$0")/../public/core-dev
+cd $( git rev-parse --show-toplevel )
 
 if [[ ! -e .svn ]]; then
 	echo "Error: Unable to find svn root."

--- a/bin/svn-git-up
+++ b/bin/svn-git-up
@@ -3,7 +3,7 @@
 #
 # Pass a branch name like 4.6 as the sole argument to checkout that branch. Otherwise, master/trunk is checked out.
 
-cd $(dirname "$0")/../public/core-git
+cd $(dirname "$0")/../public/core-dev
 
 if [[ ! -e .svn ]]; then
 	echo "Error: Unable to find svn root."

--- a/bin/svn-git-up
+++ b/bin/svn-git-up
@@ -19,16 +19,16 @@ git fetch origin --tags
 
 git_branch=master
 svn_path='^/trunk'
-if [ ! -z "$1" ] && [ "$1" != 'master' ] && [ "$1" != 'trunk' ]; then
-	git_branch=$1
+if [[ ! -z "$1" ]] && [[ "$1" != 'master' ]] && [[ "$1" != 'trunk' ]]; then
+	git_branch="$1"
 	svn_path="^/branches/$1"
 fi
 
 git stash save
-svn switch --force $svn_path --ignore-externals
+svn switch --force "${svn_path}" --ignore-externals
 svn revert -R .
-git checkout -f $git_branch
-git reset --hard origin/$git_branch
+git checkout -f "${git_branch}"
+git reset --hard "origin/${git_branch}"
 svn up --force --accept=theirs-full --ignore-externals
 
 set +x

--- a/bin/svn-git-up
+++ b/bin/svn-git-up
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Update Git and SVN repos checked out in the same directory.
+#
+# Pass a branch name like 4.6 as the sole argument to checkout that branch. Otherwise, master/trunk is checked out.
+
+cd $(dirname "$0")/../public/core-git
+
+if [[ ! -e .svn ]]; then
+	echo "Error: Unable to find svn root."
+	exit 1
+fi
+if [[ ! -e .git ]]; then
+	echo "Error: There is no git directory."
+	exit 1
+fi
+
+set -ex
+git fetch origin --tags
+
+git_branch=master
+svn_path='^/trunk'
+if [ ! -z "$1" ] && [ "$1" != 'master' ] && [ "$1" != 'trunk' ]; then
+	git_branch=$1
+	svn_path="^/branches/$1"
+fi
+
+git stash save
+svn switch --force $svn_path --ignore-externals
+svn revert -R .
+git checkout -f $git_branch
+git reset --hard origin/$git_branch
+svn up --force --accept=theirs-full --ignore-externals
+
+set +x
+set +e
+echo
+echo "----------------------------"
+
+echo "## svn status"
+if ! svn status --ignore-externals | grep -Ev '^(\?|\X)'; then
+	echo 'nothing to commit'
+fi
+
+echo
+echo "## git status"
+git status -uno

--- a/config/.env
+++ b/config/.env
@@ -1,8 +1,8 @@
 # Location of WordPress core develop directory
-WP_DEVELOP_DIR=/app/public/core-git/
+WP_DEVELOP_DIR=/app/public/core-dev/
 
 # Location of WordPress core directory to run from
-WP_CORE_DIR=/app/public/core-git/build/
+WP_CORE_DIR=/app/public/core-dev/build/
 
 # Location of WordPress core test suite
-WP_TESTS_DIR=/app/public/core-git/tests/phpunit/
+WP_TESTS_DIR=/app/public/core-dev/tests/phpunit/

--- a/config/wp-cli.yml
+++ b/config/wp-cli.yml
@@ -1,1 +1,1 @@
-path: public/core-git/build
+path: public/core-dev/build

--- a/public/functions.php
+++ b/public/functions.php
@@ -12,7 +12,7 @@
  * Otherwise it reads the core path from the 'WP_CORE_DIR' environment variable or the 'wp-cli.yml'
  * file in the directory located one level above.
  *
- * If all else fails, the function falls back to using the 'core-git/build' path.
+ * If all else fails, the function falls back to using the 'core-dev/build' path.
  *
  * @access private
  *
@@ -39,8 +39,8 @@ function _wordpressdev_detect_core_path_relative() {
 		}
 	}
 
-	// Fall back to a hard-coded 'core-git/build' as last resort.
-	return 'core-git/build';
+	// Fall back to a hard-coded 'core-dev/build' as last resort.
+	return 'core-dev/build';
 }
 
 /**


### PR DESCRIPTION
When developing patches for WordPress core—and to do development generally—using Git provides the best experience. WordPress core however uses SVN ([for the moment](https://make.wordpress.org/core/2018/12/09/on-wordpress-git/)) as the canonical source for writing changes back to WordPress. We can get the best of both worlds by checking out SVN inside of a Git clone, and then update both SVN and Git at the same time when pulling changes. An additional benefit here is that when adding the project directory to a code editor, you don't have to mess with it returning duplicate results for files that exist both in SVN and Git.

This approach has also been done by @danielbachhuber: https://danielbachhuber.com/2012/09/30/git-in-my-subversion/

To update Git and SVN concurrently, do `lando svn-git-up`. To switch to a specific branch and update, do `lando svn-git-up 4.9`. Leave the branch designation empty to switch and update `master`/`trunk`.