### PR TITLE
Add WP_DEBUG_LOG and Lando command for tailing it

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -64,5 +64,8 @@ tooling:
     service: appserver
     # TODO: This is not the ideal way to force the environment variable to be set, but the .env file does not always persist due to a Lando bug.
     cmd: "WP_TESTS_DIR=/app/public/core-git/tests/phpunit/ phpunit"
+  log:
+    service: appserver
+    cmd: "if [ ! -e /app/public/content/debug.log ]; then touch /app/public/content/debug.log; fi; echo 'Assuming WP_DEBUG_LOG enabled, tailing /app/public/content/debug.log...'; tail -f /app/public/content/debug.log"
   wp:
     service: appserver

--- a/public/wp-config.php
+++ b/public/wp-config.php
@@ -102,6 +102,10 @@ if ( ! defined( 'WP_DEBUG' ) ) {
 	define( 'WP_DEBUG', true );
 }
 
+if ( ! defined( 'WP_DEBUG_LOG' ) ) {
+	define( 'WP_DEBUG_LOG', true );
+}
+
 /* That's all, stop editing! Happy blogging. */
 
 if ( defined( 'MULTISITE' ) && MULTISITE ) {


### PR DESCRIPTION
Monitoring the PHP error log is an essential tool for development. So this enables the `WP_DEBUG_LOG` constant and adds a `lando log` command which will touch the log file if it doesn't exist yet and then start `tail`'ing it.