### PR TITLE
Add/wp admin redirect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ public
 !public/wp-tests-config.php
 !public/content/mu-plugins/.gitkeep
 !public/content/mu-plugins/allow-using-default-themes.php
+!public/content/mu-plugins/wp-admin-redirect.php
 !public/content/plugins/.gitkeep
 !public/content/themes/.gitkeep
 

--- a/public/content/mu-plugins/wp-admin-redirect.php
+++ b/public/content/mu-plugins/wp-admin-redirect.php
@@ -1,0 +1,15 @@
+<?php
+/*
+Plugin Name: WP-Admin Redirect
+Plugin URI:  https://github.com/felixarntz/wordpressdev
+Description: Redirects the plain /wp-admin/ URL to its actual location in the WordPress core subdirectory.
+Version:     1.0.0
+Author:      WordPressDev contributors
+Author URI:  https://github.com/felixarntz/wordpressdev
+*/
+
+if ( ! empty( $_SERVER['REQUEST_URI'] ) && 0 === strpos( $_SERVER['REQUEST_URI'], '/wp-admin' ) && admin_url() !== home_url( 'wp-admin/' ) ) {
+	// `wp_safe_redirect()` and `wp_redirect()` are not available here yet.
+	header( 'Location: ' . site_url( $_SERVER['REQUEST_URI'] ), true, 301 );
+	exit;
+}

--- a/public/content/mu-plugins/wp-admin-redirect.php
+++ b/public/content/mu-plugins/wp-admin-redirect.php
@@ -8,8 +8,18 @@ Author:      WordPressDev contributors
 Author URI:  https://github.com/felixarntz/wordpressdev
 */
 
-if ( ! empty( $_SERVER['REQUEST_URI'] ) && 0 === strpos( $_SERVER['REQUEST_URI'], '/wp-admin' ) && admin_url() !== home_url( 'wp-admin/' ) ) {
-	// `wp_safe_redirect()` and `wp_redirect()` are not available here yet.
-	header( 'Location: ' . site_url( $_SERVER['REQUEST_URI'] ), true, 301 );
-	exit;
-}
+add_action(
+	'template_redirect',
+	function() {
+		if ( ! is_404() ) {
+			return;
+		}
+
+		if ( empty( $_SERVER['REQUEST_URI'] ) || 0 !== strpos( $_SERVER['REQUEST_URI'], '/wp-admin' ) || admin_url() === home_url( 'wp-admin/' ) ) {
+			return;
+		}
+
+		wp_safe_redirect( site_url( $_SERVER['REQUEST_URI'] ), 301 );
+		exit;
+	}
+);


### PR DESCRIPTION
This PR adds a small MU plugin that redirects the commonly entered `/wp-admin` URL to its actual location in the WordPress core subdirectory.

See #15.