### PR TITLE
Expose npx command for tooling on appserver

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -42,6 +42,8 @@ services:
 tooling:
   npm:
     service: appserver
+  npx:
+    service: appserver
   grunt:
     service: appserver
     cmd: "npx grunt"


### PR DESCRIPTION
Exposing `npx` makes it possible to run node modules scoped to a project. For example:

```
lando npx eslint .
```