### PR TITLE
Add yarn

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -16,6 +16,10 @@ services:
       phpunit/phpunit: "^6"
     install_dependencies_as_root:
       - apt-get update -y
+      - |
+        apt-get -y install libyaml-dev;
+        yes | pecl install yaml;
+        echo 'extension=yaml.so' > /usr/local/etc/php/conf.d/yaml.ini
       - apt-get install gnupg -y
       - |
         curl -sL https://deb.nodesource.com/setup_10.x | bash -;

--- a/.lando.yml
+++ b/.lando.yml
@@ -17,8 +17,13 @@ services:
     install_dependencies_as_root:
       - apt-get update -y
       - apt-get install gnupg -y
-      - curl -sL https://deb.nodesource.com/setup_10.x | bash -
-      - apt-get install nodejs -y
+      - |
+        curl -sL https://deb.nodesource.com/setup_10.x | bash -;
+        apt-get install nodejs -y
+      - |
+        curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -;
+        echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list;
+        apt-get update && apt-get install yarn -y
       - apt-get install zip -y
       - apt-get install subversion -y
       # Allow loopback requests to work.
@@ -45,6 +50,8 @@ services:
 
 tooling:
   npm:
+    service: appserver
+  yarn:
     service: appserver
   grunt:
     service: appserver


### PR DESCRIPTION
Yarn is used instead of NPM on popular plugins like Jetpack and Yoast. It would be good to include as a tool for plugin development.