### PR TITLE
Disable WSOD protection in WP 5.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 !/public/content
 /public/content/*
+!/public/content/shutdown-handler.php
 
 !/public/content/mu-plugins
 /public/content/mu-plugins/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,19 +1,32 @@
-public
-!public/functions.php
-!public/index.php
-!public/wp-config.php
-!public/wp-tests-config.php
-!public/content/mu-plugins/.gitkeep
-!public/content/mu-plugins/allow-using-default-themes.php
-!public/content/mu-plugins/wp-admin-redirect.php
-!public/content/plugins/.gitkeep
-!public/content/themes/.gitkeep
+/public/*
+!/public/functions.php
+!/public/index.php
+!/public/phpinfo.php
+!/public/wp-config.php
+!/public/wp-tests-config.php
 
-.env
-!config/.env
+!/public/content
+/public/content/*
 
-wp-cli.yml
-!config/wp-cli.yml
+!/public/content/mu-plugins
+/public/content/mu-plugins/*
+!/public/content/mu-plugins/.gitkeep
+!/public/content/mu-plugins/allow-using-default-themes.php
+!/public/content/mu-plugins/wp-admin-redirect.php
+
+!/public/content/plugins
+/public/content/plugins/*
+!/public/content/plugins/.gitkeep
+
+!/public/content/themes
+/public/content/themes/*
+!/public/content/themes/.gitkeep
+
+/.env
+!/config/.env
+
+/wp-cli.yml
+!/config/wp-cli.yml
 
 [Tt]humbs.db
 [Dd]esktop.ini

--- a/public/content/shutdown-handler.php
+++ b/public/content/shutdown-handler.php
@@ -1,0 +1,23 @@
+<?php // phpcs:disable WordPress.Files.FileName.InvalidClassFileName
+
+/*
+ * Plugin Name: Non-Handling Shutdown Handler
+ * Description: Disable WSOD protection so that plugins will not auto-suspend during development while errors often occur.
+ * Plugin URI: https://gist.github.com/westonruter/583a42392a0b8684dc268b40d44eb7f1
+ * Plugin Author: Weston Ruter
+ */
+
+/**
+ * Class Non_Handling_Shutdown_Handler
+ */
+class Non_Handling_Shutdown_Handler extends WP_Shutdown_Handler {
+
+	/**
+	 * Override the shutdown handler to no-op.
+	 */
+	public function handle() {
+		// No-op.
+	}
+}
+
+return new Non_Handling_Shutdown_Handler();


### PR DESCRIPTION
Per https://make.wordpress.org/core/2019/01/14/php-site-health-mechanisms-in-5-1/#comment-35228:

> I’ve found the WSOD protection an annoyance during development. When I’m coding a plugin and I cause a fatal error to occur, I don’t want to suspend the plugin. Rather I want to fix the bug to make the error go away. At the moment I’m disabling WSOD on my dev environment via:
>
> https://gist.github.com/westonruter/583a42392a0b8684dc268b40d44eb7f1

I don't think WSOD protection should be enabled in this development environment.